### PR TITLE
Possible fix for checkpoint overflow

### DIFF
--- a/src/checkpoint.cpp
+++ b/src/checkpoint.cpp
@@ -68,6 +68,11 @@ int Checkpoint::GetIndex() const
 	return m_index;
 }
 
+void Checkpoint::SetIndex(int idx)
+{
+	m_index = idx;
+}
+
 float Checkpoint::GetDistFinish() const
 {
 	return m_distToFinish;

--- a/src/checkpoint.h
+++ b/src/checkpoint.h
@@ -17,6 +17,7 @@ public:
 	Checkpoint(int index, const Vec3& pos, const std::string& quadName);
 	Checkpoint(const PSX::Checkpoint& checkpoint, int index);
 	int GetIndex() const;
+    void SetIndex(int idx);
 	float GetDistFinish() const;
 	const Vec3& GetPos() const;
 	int GetUp() const;

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -183,7 +183,7 @@ bool Level::GenerateCheckpoints()
             numToRemove = numRemovable;
         }
 
-		// Euristic: Pick smallest-dist-to-next checkpoint to remove
+		// Heuristic: Pick smallest-dist-to-next checkpoint to remove
         std::unordered_set<size_t> indexesToRemove;
         auto it = distToNextMap.begin();
         for (size_t i = 0; i < numToRemove && it != distToNextMap.end(); ++i, ++it)

--- a/src/quadblock.cpp
+++ b/src/quadblock.cpp
@@ -438,6 +438,11 @@ void Quadblock::SetCheckpoint(int index)
 	m_checkpointIndex = index;
 }
 
+int Quadblock::GetCheckpoint() const
+{
+	return m_checkpointIndex;
+}
+
 void Quadblock::SetDrawDoubleSided(bool active)
 {
 	m_doubleSided = active;

--- a/src/quadblock.h
+++ b/src/quadblock.h
@@ -160,6 +160,7 @@ public:
 	void SetTerrain(uint8_t terrain);
 	void SetFlag(uint16_t flag);
 	void SetCheckpoint(int index);
+	int GetCheckpoint() const;
 	void SetDrawDoubleSided(bool active);
 	void SetCheckpointStatus(bool active);
 	void SetName(const std::string& name);


### PR DESCRIPTION
Cap the total number of generated checkpoints at 255, If the limit is exceeded:

- Preserves essential “link node” checkpoints (start/end of paths)
- Selects the least impactful checkpoints to remove using a distance-to-next heuristic
- Rebuilds checkpoint indices and cyclic up/down links
- Updates quadblock references, reassigning removed checkpoints to the nearest valid one