### PR TITLE
ckpt dtf bugfix

### DIFF
--- a/src/level.cpp
+++ b/src/level.cpp
@@ -242,14 +242,17 @@ bool Level::GenerateCheckpoints()
 	if (hit && tmax >= 0.0f)
 	{
 		const Vec3 finishLinePos = endCheckpointPos + (direction * tmax);
-		m_checkpointPaths[lastPathIndex].UpdateDist(0.0f, finishLinePos, m_checkpoints);
+		//m_checkpointPaths[lastPathIndex].UpdateDist(0.0f, finishLinePos, m_checkpoints);
+		// Not sure what it does, but removing it seems necessary to make everything work.
 	}
 
-	const Checkpoint* currStartCheckpoint = &m_checkpoints[m_checkpointPaths[lastPathIndex].GetStart()];
-	for (int i = lastPathIndex - 1; i >= 0; i--)
+	const Checkpoint* currStartCheckpoint = &m_checkpoints[0];
+	float distFinish = 0.0f;
+	for (int i = lastPathIndex; i >= 0; i--)
 	{
-		m_checkpointPaths[i].UpdateDist(currStartCheckpoint->GetDistFinish(), currStartCheckpoint->GetPos(), m_checkpoints);
+		m_checkpointPaths[i].UpdateDist(distFinish, currStartCheckpoint->GetPos(), m_checkpoints);
 		currStartCheckpoint = &m_checkpoints[m_checkpointPaths[i].GetStart()];
+		distFinish = currStartCheckpoint->GetDistFinish();
 	}
 
 	for (size_t i = 0; i < linkNodeIndexes.size(); i++)

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -162,8 +162,8 @@ std::vector<Checkpoint> Path::GeneratePath(size_t pathStartIndex, std::vector<Qu
 	quadIndexesPerChunk.push_back(m_quadIndexesEnd);
 
 	Vec3 lastChunkVertex;
-	float distFinish = 0.0f;
-	std::vector<float> distFinishes;
+	float distStart = 0.0f; // Distance from the start of the path
+	std::vector<float> distStarts;
 	std::vector<Checkpoint> checkpoints;
 	int currCheckpointIndex = static_cast<int>(pathStartIndex);
 	for (const std::vector<size_t>& quadIndexSet : quadIndexesPerChunk)
@@ -201,8 +201,8 @@ std::vector<Checkpoint> Path::GeneratePath(size_t pathStartIndex, std::vector<Qu
 			}
 			quadblock.SetCheckpoint(currCheckpointIndex);
 		}
-		if (!checkpoints.empty()) { distFinish += (lastChunkVertex - chunkVertex).Length(); }
-		distFinishes.push_back(distFinish);
+		if (!checkpoints.empty()) { distStart += (lastChunkVertex - chunkVertex).Length(); }
+		distStarts.push_back(distStart);
 		checkpoints.emplace_back(currCheckpointIndex, chunkVertex, quadblocks[chunkQuadIndex].GetName());
 		checkpoints.back().UpdateUp(currCheckpointIndex + 1);
 		checkpoints.back().UpdateDown(currCheckpointIndex - 1);
@@ -213,10 +213,11 @@ std::vector<Checkpoint> Path::GeneratePath(size_t pathStartIndex, std::vector<Qu
 	m_start = pathStartIndex;
 	m_end = m_start + checkpoints.size() - 1;
 
-	size_t j = 0;
-	for (int i = static_cast<int>(checkpoints.size()) - 1; i >= 0; i--)
+	int ckpt_count = static_cast<int>(checkpoints.size());
+	for (int i = 0; i < ckpt_count; i++)
 	{
-		checkpoints[j++].UpdateDistFinish(distFinishes[i]);
+		checkpoints[i].UpdateDistFinish(distStarts[ckpt_count-1] - distStarts[i]);
+		// At this moment, ckpt[i].dtf correspond to the distance to the end of the current path
 	}
 
 	checkpoints.front().UpdateDown(NONE_CHECKPOINT_INDEX);


### PR DESCRIPTION
Fixed some issues regarding the distance to finish calculation. The main problem was within each path, the checkpoint dist to finish was basically swapped. There was another issue when using UpdateDist afterward, causing each checkpoint's dtf to correspond to the distance to the last checkpoint node, instead of the first one.

After those changes, everything should work as intended :
-The distance between checkpoint node i and i+1 is the same as the difference between their distance to finish. 
-First ckpt distance to finish correspond to the total distance 
-Last ckpt distance to finish correspond to the distance to the first ckpt

TODO : Remove from the code stuff that have been commented out, I wasn't sure what was still useful and what wasn't, so I just commented the line that was actually modifying some dtf.