### PR TITLE
Load save lev

### DIFF
--- a/src/bsp.cpp
+++ b/src/bsp.cpp
@@ -36,6 +36,85 @@ BSP::BSP(BSPNode type, const std::vector<size_t>& quadblockIndexes, BSP* parent,
 	}
 }
 
+void BSP::PopulateBranch(PSX::BSPBranch& branch, std::vector<BSP*>& bspArray, size_t global_id)
+{
+	g_id = global_id;
+	m_id = branch.id;
+	m_node = BSPNode::BRANCH;
+	if (branch.axis.x != 0) { m_axis = AxisSplit::X; }
+	else if (branch.axis.y != 0) { m_axis = AxisSplit::Y; }
+	else if (branch.axis.z != 0) { m_axis = AxisSplit::Z; }
+	else { m_axis = AxisSplit::NONE; }
+	m_flags = branch.flag;
+	if (branch.leftChild != BSPID::EMPTY)
+	{
+		uint16_t leftId = branch.leftChild & ~BSPID::LEAF;
+		if (leftId < bspArray.size())
+		{
+			m_left = bspArray[leftId];
+			m_left->SetParent(this);
+		}
+	}
+	if (branch.rightChild != BSPID::EMPTY)
+	{
+		uint16_t rightId = branch.rightChild & ~BSPID::LEAF;
+		if (rightId < bspArray.size())
+		{
+			m_right = bspArray[rightId];
+			m_right->SetParent(this);
+		}
+	}
+	m_bbox = BoundingBox();
+	m_bbox.min = ConvertPSXVec3(branch.bbox.min, FP_ONE_GEO);
+	m_bbox.max = ConvertPSXVec3(branch.bbox.max, FP_ONE_GEO);
+	m_quadblockIndexes = std::vector<size_t>(); // Need to be set later
+}
+
+void BSP::PopulateLeaf(PSX::BSPLeaf& leaf, std::vector<BSP*>& bspArray, const std::vector<Quadblock>& quadblocks, uint32_t offQuadblocks, size_t global_id)
+{
+	g_id = global_id; 
+	m_id = leaf.id;
+	m_node = BSPNode::LEAF;
+	m_axis = AxisSplit::NONE;
+	m_flags = leaf.flag;
+	m_left = nullptr; 
+	m_right = nullptr; 
+	m_bbox = BoundingBox();
+	m_bbox.min = ConvertPSXVec3(leaf.bbox.min, FP_ONE_GEO);
+	m_bbox.max = ConvertPSXVec3(leaf.bbox.max, FP_ONE_GEO);
+	m_quadblockIndexes = std::vector<size_t>();
+	for (size_t i = 0; i < leaf.numQuads; i++)
+	{
+		uint32_t relative_offset = leaf.offQuads - offQuadblocks;
+		m_quadblockIndexes.push_back(i + relative_offset/sizeof(PSX::Quadblock));
+	}
+	for (size_t i : m_quadblockIndexes)
+	{
+		if (i < quadblocks.size()) { quadblocks[i].SetBSPID(m_id); }
+	}
+}
+
+
+void BSP::PopulateBranchQuadIndexes()
+{
+	if (m_node == BSPNode::BRANCH)
+	{
+		m_quadblockIndexes.clear();
+		if (m_left != nullptr)
+		{
+			m_left->PopulateBranchQuadIndexes();
+			const std::vector<size_t>& leftIndexes = m_left->GetQuadblockIndexes();
+			m_quadblockIndexes.insert(m_quadblockIndexes.end(), leftIndexes.begin(), leftIndexes.end());
+		}
+		if (m_right != nullptr)
+		{
+			m_right->PopulateBranchQuadIndexes();
+			const std::vector<size_t>& rightIndexes = m_right->GetQuadblockIndexes();
+			m_quadblockIndexes.insert(m_quadblockIndexes.end(), rightIndexes.begin(), rightIndexes.end());
+		}
+	}
+}
+
 size_t BSP::GetId() const
 {
 	return m_id;
@@ -143,6 +222,11 @@ std::vector<const BSP*> BSP::GetLeaves() const
 void BSP::SetQuadblockIndexes(const std::vector<size_t>& quadblockIndexes)
 {
 	m_quadblockIndexes = quadblockIndexes;
+}
+
+void BSP::SetParent(BSP* parent)
+{
+	m_parent = parent;
 }
 
 void BSP::Clear()

--- a/src/bsp.h
+++ b/src/bsp.h
@@ -38,6 +38,9 @@ class BSP
 public:
 	BSP();
 	BSP(BSPNode type, const std::vector<size_t>& quadblockIndexes, BSP* parent, const std::vector<Quadblock>& quadblocks);
+	void PopulateLeaf(PSX::BSPLeaf& leaf, std::vector<BSP*>& bspArray, const std::vector<Quadblock>& quadblocks, uint32_t offQuadblocks, size_t global_id);
+	void PopulateBranch(PSX::BSPBranch& branch, std::vector<BSP*>& bspArray, size_t global_id);
+	void PopulateBranchQuadIndexes();
 	size_t GetId() const;
 	bool IsEmpty() const;
 	bool IsValid() const;
@@ -53,6 +56,7 @@ public:
 	const std::vector<const BSP*> GetTree() const;
 	std::vector<const BSP*> GetLeaves() const;
 	void SetQuadblockIndexes(const std::vector<size_t>& quadblockIndexes);
+	void SetParent(BSP* parent);
 	void Clear();
 	void Generate(const std::vector<Quadblock>& quadblocks, const size_t maxQuadsPerLeaf, const float maxAxisLength);
 	std::vector<uint8_t> Serialize(size_t offQuads) const;

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1274,6 +1274,7 @@ bool Level::SaveLEV(const std::filesystem::path& path)
 	meshInfo.numVertices = static_cast<uint32_t>(serializedVertices.size());
 	meshInfo.offQuadblocks = static_cast<uint32_t>(offQuadblocks);
 	meshInfo.offVertices = static_cast<uint32_t>(offVertices);
+	meshInfo.unk1 = 0;
 	meshInfo.unk2 = 0;
 	meshInfo.offBSPNodes = static_cast<uint32_t>(offBSP);
 	meshInfo.numBSPNodes = static_cast<uint32_t>(serializedBSPs.size());

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -831,6 +831,40 @@ bool Level::LoadLEV(const std::filesystem::path& levFile)
 	}
 	UpdateRenderCheckpointData();
 
+	m_tropyGhost.clear();
+	m_oxideGhost.clear();
+	if (header.offExtra > 0)
+	{
+		file.seekg(offLev + std::streampos(header.offExtra));
+		PSX::LevelExtraHeader extraHeader = {};
+		Read(file, extraHeader);
+		// Read N. Tropy Ghost
+		if (extraHeader.count >= PSX::LevelExtra::N_TROPY_GHOST + 1 &&
+			extraHeader.offsets[PSX::LevelExtra::N_TROPY_GHOST] > 0)
+		{
+			file.seekg(offLev + std::streampos(extraHeader.offsets[PSX::LevelExtra::N_TROPY_GHOST]));
+			size_t ghostSize = 0;
+			if (extraHeader.count > PSX::LevelExtra::N_OXIDE_GHOST && extraHeader.offsets[PSX::LevelExtra::N_OXIDE_GHOST] > 0)
+			{
+				ghostSize = extraHeader.offsets[PSX::LevelExtra::N_OXIDE_GHOST] - extraHeader.offsets[PSX::LevelExtra::N_TROPY_GHOST];
+			}
+			else
+			{
+				ghostSize = header.offLevNavTable - extraHeader.offsets[PSX::LevelExtra::N_TROPY_GHOST];
+			}
+			m_tropyGhost.resize(ghostSize);
+			file.read(reinterpret_cast<char*>(m_tropyGhost.data()), ghostSize);
+		}
+		// Read N. Oxide Ghost
+		if (extraHeader.count >= PSX::LevelExtra::N_OXIDE_GHOST + 1 && extraHeader.offsets[PSX::LevelExtra::N_OXIDE_GHOST] > 0)
+		{
+			file.seekg(offLev + std::streampos(extraHeader.offsets[PSX::LevelExtra::N_OXIDE_GHOST]));
+			size_t ghostSize = header.offLevNavTable - extraHeader.offsets[PSX::LevelExtra::N_OXIDE_GHOST];
+			m_oxideGhost.resize(ghostSize);
+			file.read(reinterpret_cast<char*>(m_oxideGhost.data()), ghostSize);
+		}
+	}
+
 	m_loaded = true;
 	file.close();
 	GenerateRenderLevData();

--- a/src/level.h
+++ b/src/level.h
@@ -149,4 +149,7 @@ private:
 	std::vector<PSX::TextureGroup> m_rawTexGroups;
 	std::vector<uint8_t> m_rawAnimData;
 	bool m_hasRawTextureData;
+
+	std::vector<Vertex> m_originalVertices;
+	bool m_hasOriginalVertices;
 };

--- a/src/level.h
+++ b/src/level.h
@@ -145,4 +145,8 @@ private:
 	Vec3 m_rendererQueryPoint;
 	std::vector<size_t> m_rendererSelectedQuadblockIndexes;
 	size_t m_lastAnimTextureCount;
+
+	std::vector<PSX::TextureGroup> m_rawTexGroups;
+	std::vector<uint8_t> m_rawAnimData;
+	bool m_hasRawTextureData;
 };

--- a/src/psx_types.h
+++ b/src/psx_types.h
@@ -373,8 +373,8 @@ static constexpr int16_t FP_ONE = 0x1000;
 static constexpr int16_t FP_ONE_GEO = 64;
 static constexpr int16_t FP_ONE_CP = 8;
 
-static inline int16_t ConvertFloat(float x, int16_t one = FP_ONE) { return static_cast<int16_t>(x * static_cast<float>(one)); };
-static inline int16_t ConvertAngle(float x) { return static_cast<int16_t>((x * static_cast<float>(FP_ONE)) / 360.0f); }
+static inline int16_t ConvertFloat(float x, int16_t one = FP_ONE) { return static_cast<int16_t>(std::round(x * static_cast<float>(one))); };
+static inline int16_t ConvertAngle(float x) { return static_cast<int16_t>(std::round((x * static_cast<float>(FP_ONE)) / 360.0f)); }
 static inline float ConvertFP(int16_t fp, int16_t one = FP_ONE) { return static_cast<float>(fp) / static_cast<float>(one); }
 static inline float ConvertFPAngle(int16_t fp) { return (static_cast<float>(fp) * 360.0f) / static_cast<float>(FP_ONE); }
 

--- a/src/quadblock.cpp
+++ b/src/quadblock.cpp
@@ -961,7 +961,7 @@ bool Quadblock::HasRawQuadblock() const
 	return m_hasRawQuadblock; 
 }
 
-const PSX::Quadblock& GetRawQuadblock() const 
+const Quadblock::PSX::Quadblock& GetRawQuadblock() const
 {
 	return m_rawQuadblock; 
 }

--- a/src/quadblock.cpp
+++ b/src/quadblock.cpp
@@ -8,6 +8,7 @@
 
 Quadblock::Quadblock(const std::string& name, Tri& t0, Tri& t1, Tri& t2, Tri& t3, const Vec3& normal, const std::string& material, bool hasUV, UpdateFilterCallback filterCallback)
 {
+	m_hasRawQuadblock = false;
 	std::unordered_map<Vec3, unsigned> vRefCount;
 	for (size_t i = 0; i < 3; i++)
 	{
@@ -210,6 +211,7 @@ Quadblock::Quadblock(const std::string& name, Tri& t0, Tri& t1, Tri& t2, Tri& t3
 
 Quadblock::Quadblock(const std::string& name, Quad& q0, Quad& q1, Quad& q2, Quad& q3, const Vec3& normal, const std::string& material, bool hasUV, UpdateFilterCallback filterCallback)
 {
+	m_hasRawQuadblock = false;
 	std::unordered_map<Vec3, unsigned> vRefCount;
 	for (size_t i = 0; i < 4; i++)
 	{
@@ -390,6 +392,7 @@ Quadblock::Quadblock(const std::string& name, Quad& q0, Quad& q1, Quad& q2, Quad
 
 Quadblock::Quadblock(const PSX::Quadblock& quadblock, const std::vector<PSX::Vertex>& vertices, UpdateFilterCallback filterCallback)
 {
+	m_hasRawQuadblock = false;
 	uint16_t reverseIndexMapping[NUM_VERTICES_QUADBLOCK] = { 0, 2, 6, 8, 1, 3, 4, 5, 7 };
 	for (size_t i = 0; i < NUM_VERTICES_QUADBLOCK; i++)
 	{
@@ -415,6 +418,8 @@ Quadblock::Quadblock(const PSX::Quadblock& quadblock, const std::vector<PSX::Ver
 	m_material = "default";
 	m_triblock = false;
 	m_filterCallback = filterCallback;
+	m_bbox.min = ConvertPSXVec3(quadblock.bbox.min, FP_ONE_GEO);
+	m_bbox.max = ConvertPSXVec3(quadblock.bbox.max, FP_ONE_GEO);
 }
 
 const std::string& Quadblock::GetName() const
@@ -823,61 +828,68 @@ std::vector<uint8_t> Quadblock::Serialize(size_t id, size_t offTextures, const s
 {
 	PSX::Quadblock quadblock = {};
 	std::vector<uint8_t> buffer(sizeof(quadblock));
+
+	if (m_hasRawQuadblock) 
+	{ 
+		quadblock = m_rawQuadblock; 
+	}
+	else
+	{
+		quadblock.drawOrderLow = m_doubleSided ? (1 << 31) : 0;
+		for (size_t i = 0; i < NUM_FACES_QUADBLOCK; i++)
+		{
+			uint32_t packedFace = m_faceRotateFlip[i] | (m_faceDrawMode[i] << 3);
+			quadblock.drawOrderLow |= packedFace << (8 + i * 5);
+		}
+		quadblock.drawOrderHigh = 0;
+		if (m_animated)
+		{
+			quadblock.offMidTextures[0] = static_cast<uint32_t>(m_animTexOffset[0] | 1);
+			quadblock.offMidTextures[1] = static_cast<uint32_t>(m_animTexOffset[1] | 1);
+			quadblock.offMidTextures[2] = static_cast<uint32_t>(m_animTexOffset[2] | 1);
+			quadblock.offMidTextures[3] = static_cast<uint32_t>(m_animTexOffset[3] | 1);
+			quadblock.offLowTexture = static_cast<uint32_t>(offTextures + (m_textureIDs[4] * sizeof(PSX::TextureGroup)));
+		}
+		else
+		{
+			quadblock.offMidTextures[0] = static_cast<uint32_t>(offTextures + (m_textureIDs[0] * sizeof(PSX::TextureGroup)));
+			quadblock.offMidTextures[1] = static_cast<uint32_t>(offTextures + (m_textureIDs[1] * sizeof(PSX::TextureGroup)));
+			quadblock.offMidTextures[2] = static_cast<uint32_t>(offTextures + (m_textureIDs[2] * sizeof(PSX::TextureGroup)));
+			quadblock.offMidTextures[3] = static_cast<uint32_t>(offTextures + (m_textureIDs[3] * sizeof(PSX::TextureGroup)));
+			quadblock.offLowTexture = static_cast<uint32_t>(offTextures + (m_textureIDs[4] * sizeof(PSX::TextureGroup)));
+		}
+		quadblock.weatherIntensity = 0;
+		quadblock.weatherVanishRate = 0;	
+		const size_t idVis = id / 32;
+		quadblock.id = static_cast<uint16_t>((32 * idVis) + (31 - (id % 32)));
+		quadblock.triNormalVecBitshift = static_cast<uint8_t>(std::round(std::log2(std::max(ComputeNormalVector(0, 2, 6).Length(), ComputeNormalVector(2, 8, 6).Length()) * 512.0f)));
+		auto CalculateNormalDividend = [this](size_t id0, size_t id1, size_t id2, float scaler) -> int16_t
+			{
+				return static_cast<int16_t>(std::round(scaler / ComputeNormalVector(id0, id1, id2).Length()));
+			};
+		float scaler = static_cast<float>(1 << quadblock.triNormalVecBitshift);
+		quadblock.triNormalVecDividend[0] = CalculateNormalDividend(0, 1, 3, scaler);
+		quadblock.triNormalVecDividend[1] = CalculateNormalDividend(1, 4, 3, scaler);
+		quadblock.triNormalVecDividend[2] = CalculateNormalDividend(4, 1, 2, scaler);
+		quadblock.triNormalVecDividend[3] = CalculateNormalDividend(3, 4, 6, scaler);
+		quadblock.triNormalVecDividend[4] = CalculateNormalDividend(7, 4, 5, scaler);
+		quadblock.triNormalVecDividend[5] = CalculateNormalDividend(5, 8, 7, scaler);
+		quadblock.triNormalVecDividend[6] = CalculateNormalDividend(2, 5, 4, scaler);
+		quadblock.triNormalVecDividend[7] = CalculateNormalDividend(6, 4, 7, scaler);
+		quadblock.triNormalVecDividend[9] = CalculateNormalDividend(2, 8, 6, scaler);
+		quadblock.triNormalVecDividend[8] = CalculateNormalDividend(0, 2, 6, scaler);
+	}
+
 	for (size_t i = 0; i < NUM_VERTICES_QUADBLOCK; i++)
 	{
 		quadblock.index[i] = static_cast<uint16_t>(vertexIndexes[i]);
 	}
 	quadblock.flags = m_flags;
-	quadblock.drawOrderLow = m_doubleSided ? (1 << 31) : 0;
-	for (size_t i = 0; i < NUM_FACES_QUADBLOCK; i++)
-	{
-		uint32_t packedFace = m_faceRotateFlip[i] | (m_faceDrawMode[i] << 3);
-		quadblock.drawOrderLow |= packedFace << (8 + i * 5);
-	}
-	quadblock.drawOrderHigh = 0;
-	if (m_animated)
-	{
-		quadblock.offMidTextures[0] = static_cast<uint32_t>(m_animTexOffset[0] | 1);
-		quadblock.offMidTextures[1] = static_cast<uint32_t>(m_animTexOffset[1] | 1);
-		quadblock.offMidTextures[2] = static_cast<uint32_t>(m_animTexOffset[2] | 1);
-		quadblock.offMidTextures[3] = static_cast<uint32_t>(m_animTexOffset[3] | 1);
-		quadblock.offLowTexture = static_cast<uint32_t>(offTextures + (m_textureIDs[4] * sizeof(PSX::TextureGroup)));
-	}
-	else
-	{
-		quadblock.offMidTextures[0] = static_cast<uint32_t>(offTextures + (m_textureIDs[0] * sizeof(PSX::TextureGroup)));
-		quadblock.offMidTextures[1] = static_cast<uint32_t>(offTextures + (m_textureIDs[1] * sizeof(PSX::TextureGroup)));
-		quadblock.offMidTextures[2] = static_cast<uint32_t>(offTextures + (m_textureIDs[2] * sizeof(PSX::TextureGroup)));
-		quadblock.offMidTextures[3] = static_cast<uint32_t>(offTextures + (m_textureIDs[3] * sizeof(PSX::TextureGroup)));
-		quadblock.offLowTexture = static_cast<uint32_t>(offTextures + (m_textureIDs[4] * sizeof(PSX::TextureGroup)));
-	}
+	quadblock.speedImpact = static_cast<int8_t>(m_downforce);
+	quadblock.terrain = m_terrain;
+	quadblock.checkpointIndex = static_cast<uint8_t>(m_checkpointIndex);
 	quadblock.bbox.min = ConvertVec3(m_bbox.min, FP_ONE_GEO);
 	quadblock.bbox.max = ConvertVec3(m_bbox.max, FP_ONE_GEO);
-	quadblock.terrain = m_terrain;
-	quadblock.weatherIntensity = 0;
-	quadblock.weatherVanishRate = 0;
-	quadblock.speedImpact = static_cast<int8_t>(m_downforce);
-	const size_t idVis = id / 32;
-	quadblock.id = static_cast<uint16_t>((32 * idVis) + (31 - (id % 32)));
-	quadblock.checkpointIndex = static_cast<uint8_t>(m_checkpointIndex);
-	quadblock.triNormalVecBitshift = static_cast<uint8_t>(std::round(std::log2(std::max(ComputeNormalVector(0, 2, 6).Length(), ComputeNormalVector(2, 8, 6).Length()) * 512.0f)));
-
-	auto CalculateNormalDividend = [this](size_t id0, size_t id1, size_t id2, float scaler) -> int16_t
-		{
-			return static_cast<int16_t>(std::round(scaler / ComputeNormalVector(id0, id1, id2).Length()));
-		};
-
-	float scaler = static_cast<float>(1 << quadblock.triNormalVecBitshift);
-	quadblock.triNormalVecDividend[0] = CalculateNormalDividend(0, 1, 3, scaler);
-	quadblock.triNormalVecDividend[1] = CalculateNormalDividend(1, 4, 3, scaler);
-	quadblock.triNormalVecDividend[2] = CalculateNormalDividend(4, 1, 2, scaler);
-	quadblock.triNormalVecDividend[3] = CalculateNormalDividend(3, 4, 6, scaler);
-	quadblock.triNormalVecDividend[4] = CalculateNormalDividend(7, 4, 5, scaler);
-	quadblock.triNormalVecDividend[5] = CalculateNormalDividend(5, 8, 7, scaler);
-	quadblock.triNormalVecDividend[6] = CalculateNormalDividend(2, 5, 4, scaler);
-	quadblock.triNormalVecDividend[7] = CalculateNormalDividend(6, 4, 7, scaler);
-	quadblock.triNormalVecDividend[9] = CalculateNormalDividend(2, 8, 6, scaler); /* low LoD */
-	quadblock.triNormalVecDividend[8] = CalculateNormalDividend(0, 2, 6, scaler); /* low LoD */
 	std::memcpy(buffer.data(), &quadblock, sizeof(quadblock));
 	return buffer;
 }
@@ -936,4 +948,20 @@ void Quadblock::ComputeBoundingBox()
 	}
 	m_bbox.min = min;
 	m_bbox.max = max;
+}
+
+void Quadblock::SetRawQuadblock(const PSX::Quadblock& quadblock)
+{
+	m_rawQuadblock = quadblock;
+	m_hasRawQuadblock = true;
+}
+
+bool Quadblock::HasRawQuadblock() const 
+{
+	return m_hasRawQuadblock; 
+}
+
+const PSX::Quadblock& GetRawQuadblock() const 
+{
+	return m_rawQuadblock; 
 }

--- a/src/quadblock.cpp
+++ b/src/quadblock.cpp
@@ -961,7 +961,7 @@ bool Quadblock::HasRawQuadblock() const
 	return m_hasRawQuadblock; 
 }
 
-const Quadblock::PSX::Quadblock& GetRawQuadblock() const
+const PSX::Quadblock& Quadblock::GetRawQuadblock() const
 {
 	return m_rawQuadblock; 
 }

--- a/src/quadblock.h
+++ b/src/quadblock.h
@@ -169,6 +169,9 @@ public:
 	std::vector<uint8_t> Serialize(size_t id, size_t offTextures, const std::vector<size_t>& vertexIndexes) const;
 	bool RenderUI(size_t checkpointCount, bool& resetBsp);
 	Vec3 ComputeNormalVector(size_t id0, size_t id1, size_t id2) const;
+	void SetRawQuadblock(const PSX::Quadblock& quadblock);
+	bool HasRawQuadblock() const;
+	const PSX::Quadblock& GetRawQuadblock() const;
 
 private:
 	void ResetUVs();
@@ -211,6 +214,9 @@ private:
 	std::filesystem::path m_texPath;
 	size_t m_renderPrimitiveIndex = RENDER_INDEX_NONE;
 	UpdateFilterCallback m_filterCallback;
+
+	PSX::Quadblock m_rawQuadblock;
+	bool m_hasRawQuadblock;
 };
 
 class QuadException : public std::exception

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -35,7 +35,7 @@ std::vector<uint8_t> Vertex::Serialize() const
 	PSX::Vertex v = {};
 	std::vector<uint8_t> buffer(sizeof(v));
 	v.pos = ConvertVec3(m_pos, FP_ONE_GEO);
-	v.flags = VertexFlags::NONE;
+	v.flags = m_flags;
 	v.colorHi = ConvertColor(m_colorHigh);
 	v.colorLo = ConvertColor(m_colorLow);
 	std::memcpy(buffer.data(), &v, sizeof(v));

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -20,7 +20,14 @@ public:
 	std::vector<uint8_t> Serialize() const;
 	Color GetColor(bool high) const;
 	std::vector<Primitive> ToGeometry(bool highColor = true) const;
-	inline bool operator==(const Vertex& v) const { return (m_pos == v.m_pos) && (m_flags == v.m_flags) && (m_colorHigh == v.m_colorHigh) && (m_colorLow == v.m_colorLow); };
+	inline bool operator==(const Vertex& v) const {
+		PSX::Vec3 pos1 = ConvertVec3(m_pos, FP_ONE_GEO);
+		PSX::Vec3 pos2 = ConvertVec3(v.m_pos, FP_ONE_GEO);
+		return (pos1.x == pos2.x && pos1.y == pos2.y && pos1.z == pos2.z) &&
+			(m_flags == v.m_flags) &&
+			(m_colorHigh == v.m_colorHigh) &&
+			(m_colorLow == v.m_colorLow);
+	}
 
 public:
 	Vec3 m_pos;
@@ -39,8 +46,11 @@ struct std::hash<Vertex>
 {
 	inline std::size_t operator()(const Vertex& key) const noexcept
 	{
+		PSX::Vec3 pos = ConvertVec3(key.m_pos, FP_ONE_GEO);
 		std::size_t seed = 0;
-		HashCombine(seed, key.m_pos);
+		HashCombine(seed, pos.x);
+		HashCombine(seed, pos.y);
+		HashCombine(seed, pos.z);
 		HashCombine(seed, key.m_flags);
 		HashCombine(seed, key.m_colorHigh);
 		HashCombine(seed, key.m_colorLow);


### PR DESCRIPTION
With this PR, CTE should be able to load a .lev file (created by CTE, vanilla track would take more work), and save it again, without losing data.

Missing feature : Loading VisTree with loadLEV (I tried to preserve it, but it crashed when I tried to modify it afterward, i'll investigate later)

Important note : To get "perfect" recreation of the .lev file, some raw data needs to be stored.
Currently it's hardocded to be restored in saveLEV. It means you can't modify : 
- Vertices
- Textures
- Quadblocks (partially)

In quadblock, you can modify only : 
- flags
- speed impact /downforce
- terrain
- checkpoint index
- BBox