### PR TITLE
Splitlines

### DIFF
--- a/python_bindings/cte_bindings.cpp
+++ b/python_bindings/cte_bindings.cpp
@@ -285,7 +285,7 @@ void init_crashteameditor(py::module_& m)
 		.export_values();
 
 	py::class_<QuadFlags>(m, "QuadFlags")
-		.def_readonly_static("INVISIBLE", &QuadFlags::INVISIBLE)
+		.def_readonly_static("REFLECTION_2", &QuadFlags::REFLECTION2)
 		.def_readonly_static("MOON_GRAVITY", &QuadFlags::MOON_GRAVITY)
 		.def_readonly_static("REFLECTION", &QuadFlags::REFLECTION)
 		.def_readonly_static("KICKERS", &QuadFlags::KICKERS)

--- a/python_bindings/cte_bindings.cpp
+++ b/python_bindings/cte_bindings.cpp
@@ -285,9 +285,9 @@ void init_crashteameditor(py::module_& m)
 		.export_values();
 
 	py::class_<QuadFlags>(m, "QuadFlags")
-		.def_readonly_static("REFLECTION_2", &QuadFlags::REFLECTION2)
+		.def_readonly_static("REFLECTION_2", &QuadFlags::REFLECTION_2)
 		.def_readonly_static("MOON_GRAVITY", &QuadFlags::MOON_GRAVITY)
-		.def_readonly_static("REFLECTION", &QuadFlags::REFLECTION)
+		.def_readonly_static("REFLECTION_1", &QuadFlags::REFLECTION_1)
 		.def_readonly_static("KICKERS", &QuadFlags::KICKERS)
 		.def_readonly_static("OUT_OF_BOUNDS", &QuadFlags::OUT_OF_BOUNDS)
 		.def_readonly_static("NEVER_USED", &QuadFlags::NEVER_USED)

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1127,7 +1127,7 @@ bool Level::SaveLEV(const std::filesystem::path& path)
 	for (size_t i = 0; i < bspLeaves.size(); i++) { leafToMatrix[bspLeaves[i]] = i; }
 	for (const Quadblock* quad : orderedQuads)
 	{
-		if (quad->GetFlags() & (QuadFlags::INVISIBLE | QuadFlags::INVISIBLE_TRIGGER))
+		if (quad->GetFlags() & QuadFlags::INVISIBLE_TRIGGER)
 		{
 			visibleQuadsAll[quadIndex / BITS_PER_SLOT] &= ~(1 << (quadIndex % BITS_PER_SLOT));
 		}

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -422,6 +422,11 @@ bool Level::LoadPreset(const std::filesystem::path& filename)
 		if (json.contains("skyGradient")) { m_skyGradient = json["skyGradient"]; }
 		if (json.contains("clearColor")) { m_clearColor = json["clearColor"]; }
 		if (json.contains("stars")) { json["stars"].get_to(m_stars); }
+		if (json.contains("splitLines"))
+		{
+			m_splitLines[0] = json["splitLines"][0];
+			m_splitLines[1] = json["splitLines"][1];
+		}
 		if (json.contains("skyboxObjPath"))
 		{
 			std::string skyboxPath = json["skyboxObjPath"];
@@ -579,6 +584,7 @@ bool Level::SavePreset(const std::filesystem::path& path)
 	levelJson["skyGradient"] = m_skyGradient;
 	levelJson["clearColor"] = m_clearColor;
 	levelJson["stars"] = m_stars;
+	levelJson["splitLines"] = { m_splitLines[0], m_splitLines[1] };
 	if (!m_skybox.m_objPath.empty()) { levelJson["skyboxObjPath"] = m_skybox.m_objPath.string(); }
 	SaveJSON(dirPath / "level.json", levelJson);
 

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -82,6 +82,8 @@ void Level::Clear(bool clearErrors)
 	m_lastAnimTextureCount = 0;
 	DeleteMaterials(this);
 	m_skybox.Clear();
+	m_splitLines[0] = 0.0;
+	m_splitLines[1] = 0.0;
 
 	for (Model* model : m_models)
 	{
@@ -732,6 +734,8 @@ bool Level::LoadLEV(const std::filesystem::path& levFile)
 	m_configFlags = header.config;
 	m_clearColor = ConvertColor(header.clear);
 	m_stars = ConvertStars(header.stars);
+	m_splitLines[0] = ConvertFP(header.splitLines[0], FP_ONE_GEO);
+	m_splitLines[1] = ConvertFP(header.splitLines[1], FP_ONE_GEO);
 	for (size_t i = 0; i < m_spawn.size(); i++)
 	{
 		m_spawn[i].pos = ConvertPSXVec3(header.driverSpawn[i].pos, FP_ONE_GEO);
@@ -1299,6 +1303,8 @@ bool Level::SaveLEV(const std::filesystem::path& path)
 		header.skyGradient[i].colorTo = ConvertColor(m_skyGradient[i].colorTo);
 	}
 	header.stars = ConvertStars(m_stars);
+	header.splitLines[0] = ConvertFloat(m_splitLines[0], FP_ONE_GEO);
+	header.splitLines[1] = ConvertFloat(m_splitLines[1], FP_ONE_GEO);
 	header.offExtra = static_cast<uint32_t>(offExtraHeader);
 	header.numCheckpointNodes = static_cast<uint32_t>(m_checkpoints.size());
 	header.offCheckpointNodes = static_cast<uint32_t>(offCheckpoints);

--- a/src/level.h
+++ b/src/level.h
@@ -121,6 +121,7 @@ private:
 	std::array<ColorGradient, NUM_GRADIENT> m_skyGradient;
 	Color m_clearColor;
 	Stars m_stars;
+	float m_splitLines[2];
 	std::vector<uint8_t> m_tropyGhost;
 	std::vector<uint8_t> m_oxideGhost;
 	std::vector<Quadblock> m_quadblocks;

--- a/src/levelui.cpp
+++ b/src/levelui.cpp
@@ -515,6 +515,31 @@ void Level::RenderUI(Renderer& renderer)
 				ImGui::TreePop();
 			}
 
+			if (ImGui::TreeNode("SplitLines"))
+			{
+				ImGui::Text("SplitLine 1:"); 
+				ImGui::SameLine(); 
+				ImGui::InputFloat("##sl1", &m_splitLines[0]);
+				ImGui::SetItemTooltip("Reflection 1 flag\n");
+				ImGui::SameLine();
+				if (ImGui::Button(("Set from selection##")))
+				{
+					m_splitLines[0] = m_rendererQueryPoint.y;
+				}
+
+				ImGui::Text("SplitLine 2:");
+				ImGui::SameLine();
+				ImGui::InputFloat("##sl2", &m_splitLines[1]);
+				ImGui::SetItemTooltip("Reflection 2 flag + water\n");
+				ImGui::SameLine();
+				if (ImGui::Button(("Set from selection##")))
+				{
+					m_splitLines[1] = m_rendererQueryPoint.y;
+				}
+
+				ImGui::TreePop();
+			}
+
 			if (ImGui::TreeNode("Skybox"))
 			{
 				if (m_skybox.RenderUI())

--- a/src/levelui.cpp
+++ b/src/levelui.cpp
@@ -522,7 +522,7 @@ void Level::RenderUI(Renderer& renderer)
 				ImGui::InputFloat("##sl1", &m_splitLines[0]);
 				ImGui::SetItemTooltip("Reflection 1 flag\n");
 				ImGui::SameLine();
-				if (ImGui::Button(("Set from selection##")))
+				if (ImGui::Button(("Set from selection##1")))
 				{
 					m_splitLines[0] = m_rendererQueryPoint.y;
 				}
@@ -532,7 +532,7 @@ void Level::RenderUI(Renderer& renderer)
 				ImGui::InputFloat("##sl2", &m_splitLines[1]);
 				ImGui::SetItemTooltip("Reflection 2 flag + water\n");
 				ImGui::SameLine();
-				if (ImGui::Button(("Set from selection##")))
+				if (ImGui::Button(("Set from selection##2")))
 				{
 					m_splitLines[1] = m_rendererQueryPoint.y;
 				}

--- a/src/levelui.cpp
+++ b/src/levelui.cpp
@@ -530,7 +530,7 @@ void Level::RenderUI(Renderer& renderer)
 				ImGui::Text("SplitLine 2:");
 				ImGui::SameLine();
 				ImGui::InputFloat("##sl2", &m_splitLines[1]);
-				ImGui::SetItemTooltip("Reflection 2 flag + water\n");
+				ImGui::SetItemTooltip("Reflection 2 flag\n");
 				ImGui::SameLine();
 				if (ImGui::Button(("Set from selection##2")))
 				{

--- a/src/psx_types.h
+++ b/src/psx_types.h
@@ -200,7 +200,7 @@ namespace PSX
 		uint32_t numSCVertices; // 0x174
 		uint32_t offSCVertices; // 0x178
 		Stars stars; // 0x17C
-		uint8_t splitLines[4]; // 0x184
+		int16_t splitLines[2]; // 0x184
 		uint32_t offLevNavTable; // 0x188
 		uint32_t unk_0x18C; // 0x18C
 		uint32_t offVisMem; // 0x190

--- a/src/quadblock.h
+++ b/src/quadblock.h
@@ -19,7 +19,7 @@ static constexpr size_t RENDER_INDEX_NONE = std::numeric_limits<size_t>::max();
 
 struct QuadFlags
 {
-	static constexpr uint16_t INVISIBLE = 1 << 0;
+	static constexpr uint16_t REFLECTION2 = 1 << 0;
 	static constexpr uint16_t MOON_GRAVITY = 1 << 1;
 	static constexpr uint16_t REFLECTION = 1 << 2;
 	static constexpr uint16_t KICKERS = 1 << 3;
@@ -37,11 +37,11 @@ struct QuadFlags
 	static constexpr uint16_t INVISIBLE_TRIGGER = 1 << 15;
 	static constexpr uint16_t DEFAULT = GROUND | COLLISION_TRIGGER;
 	static inline const std::unordered_map<std::string, uint16_t> LABELS = {
-		{"Invisible", INVISIBLE}, {"Moon Gravity", MOON_GRAVITY}, {"Reflection", REFLECTION},
+		{"Reflection 2", REFLECTION2}, {"Moon Gravity", MOON_GRAVITY}, {"Reflection 1", REFLECTION},
 		{"Kickers (?)", KICKERS}, {"Out of Bounds", OUT_OF_BOUNDS}, {"Never Used (?)", NEVER_USED},
 		{"Trigger Script", TRIGGER_SCRIPT }, {"Reverb", REVERB}, {"Kickers Two (?)", KICKERS_TWO},
 		{"Mask Grab", MASK_GRAB }, {"Tiger Temple Door", TIGER_TEMPLE_DOOR}, {"Collision Trigger", COLLISION_TRIGGER},
-		{"Ground", GROUND}, {"Wall", WALL}, {"No Colision", NO_COLLISION}, {"Invisible Trigger", INVISIBLE_TRIGGER}
+		{"Ground", GROUND}, {"Wall", WALL}, {"No Collision", NO_COLLISION}, {"Invisible Trigger", INVISIBLE_TRIGGER}
 	};
 };
 

--- a/src/quadblock.h
+++ b/src/quadblock.h
@@ -19,9 +19,9 @@ static constexpr size_t RENDER_INDEX_NONE = std::numeric_limits<size_t>::max();
 
 struct QuadFlags
 {
-	static constexpr uint16_t REFLECTION2 = 1 << 0;
+	static constexpr uint16_t REFLECTION_2 = 1 << 0;
 	static constexpr uint16_t MOON_GRAVITY = 1 << 1;
-	static constexpr uint16_t REFLECTION = 1 << 2;
+	static constexpr uint16_t REFLECTION_1 = 1 << 2;
 	static constexpr uint16_t KICKERS = 1 << 3;
 	static constexpr uint16_t OUT_OF_BOUNDS = 1 << 4;
 	static constexpr uint16_t NEVER_USED = 1 << 5;
@@ -37,7 +37,7 @@ struct QuadFlags
 	static constexpr uint16_t INVISIBLE_TRIGGER = 1 << 15;
 	static constexpr uint16_t DEFAULT = GROUND | COLLISION_TRIGGER;
 	static inline const std::unordered_map<std::string, uint16_t> LABELS = {
-		{"Reflection 2", REFLECTION2}, {"Moon Gravity", MOON_GRAVITY}, {"Reflection 1", REFLECTION},
+		{"Reflection 2", REFLECTION_2}, {"Moon Gravity", MOON_GRAVITY}, {"Reflection 1", REFLECTION_1},
 		{"Kickers (?)", KICKERS}, {"Out of Bounds", OUT_OF_BOUNDS}, {"Never Used (?)", NEVER_USED},
 		{"Trigger Script", TRIGGER_SCRIPT }, {"Reverb", REVERB}, {"Kickers Two (?)", KICKERS_TWO},
 		{"Mask Grab", MASK_GRAB }, {"Tiger Temple Door", TIGER_TEMPLE_DOOR}, {"Collision Trigger", COLLISION_TRIGGER},


### PR DESCRIPTION
Implemented the SplitLines for the level (was always set to 0x0 before)
It handle which horizontal plane is used for the reflection flag and formerly called invisible flag.
Those flag have been renamed to Reflection 1 and Reflection 2, and are handled by SplitLine 1 and Splitline 2.
It's now possible to have 2 different height of reflection quads, and they are not hardocded to 0.0 anymore.
Note that is seems that mud and water terrains stay hardcoded at y = 0.
More research needs to be done on what else is affected by the splitlines, maybe it's more than just the reflection flags